### PR TITLE
Use static providers when returning the received implementation

### DIFF
--- a/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/MainModule.java
+++ b/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/MainModule.java
@@ -11,7 +11,7 @@ public class MainModule {
 
     @ActivityScope
     @Provides
-    public SalutationUseCase provideSalutationUseCase() {
+    public static SalutationUseCase provideSalutationUseCase() {
         return new SalutationUseCase();
     }
 }

--- a/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/confirmation/ConfirmationModule.java
+++ b/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/confirmation/ConfirmationModule.java
@@ -27,19 +27,19 @@ public class ConfirmationModule {
 
     @FragmentScope
     @Provides
-    public Confirmation.Presenter providePresenter(final ConfirmationPresenter presenter) {
+    public static Confirmation.Presenter providePresenter(final ConfirmationPresenter presenter) {
         return presenter;
     }
 
     @FragmentScope
     @Provides
-    public Confirmation.Navigator provideNavigator(final MainNavigator navigator) {
+    public static Confirmation.Navigator provideNavigator(final MainNavigator navigator) {
         return navigator;
     }
 
     @FragmentScope
     @Provides
-    public ConfirmationUseCase provideUseCase(final SalutationUseCase useCase) {
+    public static ConfirmationUseCase provideUseCase(final SalutationUseCase useCase) {
         return useCase;
     }
 }

--- a/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/farewell/FarewellModule.java
+++ b/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/farewell/FarewellModule.java
@@ -25,7 +25,7 @@ public class FarewellModule {
 
     @FragmentScope
     @Provides
-    public Farewell.Presenter providePresenter(final FarewellPresenter presenter) {
+    public static Farewell.Presenter providePresenter(final FarewellPresenter presenter) {
         return presenter;
     }
 

--- a/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/firstname/FirstNameModule.java
+++ b/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/firstname/FirstNameModule.java
@@ -15,19 +15,19 @@ public class FirstNameModule {
 
     @FragmentScope
     @Provides
-    public FirstName.Presenter providePresenter(final FirstNamePresenter presenter) {
+    public static FirstName.Presenter providePresenter(final FirstNamePresenter presenter) {
         return presenter;
     }
 
     @FragmentScope
     @Provides
-    public FirstName.Navigator provideNavigator(final MainNavigator navigator) {
+    public static FirstName.Navigator provideNavigator(final MainNavigator navigator) {
         return navigator;
     }
 
     @FragmentScope
     @Provides
-    public FirstNameUseCase provideUseCase(final SalutationUseCase useCase) {
+    public static FirstNameUseCase provideUseCase(final SalutationUseCase useCase) {
         return useCase;
     }
 }

--- a/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/lastname/LastNameModule.java
+++ b/dagger-component-example/src/main/java/es/iridiobis/nonconfiguration/core/injection/main/lastname/LastNameModule.java
@@ -27,19 +27,19 @@ public class LastNameModule {
 
     @FragmentScope
     @Provides
-    public LastName.Presenter providePresenter(final LastNamePresenter presenter) {
+    public static LastName.Presenter providePresenter(final LastNamePresenter presenter) {
         return presenter;
     }
 
     @FragmentScope
     @Provides
-    public LastName.Navigator provideNavigator(final MainNavigator navigator) {
+    public static LastName.Navigator provideNavigator(final MainNavigator navigator) {
         return navigator;
     }
 
     @FragmentScope
     @Provides
-    public LastNameUseCase provideUseCase(final SalutationUseCase useCase) {
+    public static LastNameUseCase provideUseCase(final SalutationUseCase useCase) {
         return useCase;
     }
 }


### PR DESCRIPTION
As it can be seen in the Dagger documentation it is recommended to use static provides methods when it just binds an implementation to an interface. [Dagger user guide](https://google.github.io/dagger/users-guide.html#satisfying-dependencies)

The FAQ also says that static provides often perform better than instance provides methods [Better static provides](https://google.github.io/dagger/faq.html#what-do-i-do-instead)

You can check the generated code to see the differences 😉 